### PR TITLE
Issue: GoogleIdTokenVerifier is not serializable #4

### DIFF
--- a/src/main/java/org/mikotin/googlesignin/events/UserLoginEvent.java
+++ b/src/main/java/org/mikotin/googlesignin/events/UserLoginEvent.java
@@ -1,7 +1,10 @@
 package org.mikotin.googlesignin.events;
 
-public class UserLoginEvent {
-    private String userId;
+import java.io.Serializable;
+
+public class UserLoginEvent implements Serializable{
+	private static final long serialVersionUID = -9016840461179575979L;
+	private String userId;
     private String email;
     private String name;
     private String pictureUrl;

--- a/src/main/java/org/mikotin/googlesignin/events/internal/InternalSignInEvent.java
+++ b/src/main/java/org/mikotin/googlesignin/events/internal/InternalSignInEvent.java
@@ -11,7 +11,8 @@ import com.vaadin.flow.component.EventData;
  */
 @DomEvent("google-signin-aware-success")
 public class InternalSignInEvent extends ComponentEvent<GoogleSignin> {
-    private String idToken;
+	private static final long serialVersionUID = 7076997587238977553L;
+	private String idToken;
 
     public InternalSignInEvent(GoogleSignin source, boolean fromClient,
             @EventData("event.detail.id_token") String idToken) {

--- a/src/main/java/org/mikotin/googlesignin/events/internal/InternalSignOutEvent.java
+++ b/src/main/java/org/mikotin/googlesignin/events/internal/InternalSignOutEvent.java
@@ -7,7 +7,9 @@ import com.vaadin.flow.component.DomEvent;
 
 @DomEvent("google-signout-attempted")
 public class InternalSignOutEvent extends ComponentEvent<GoogleSignin> {
-    public InternalSignOutEvent(GoogleSignin source, boolean fromClient) {
+	private static final long serialVersionUID = 582900770044067825L;
+
+	public InternalSignOutEvent(GoogleSignin source, boolean fromClient) {
         super(source, fromClient);
     }
 }


### PR DESCRIPTION
-Add serializable runnable and consumer
-Add serialVersionUID
-Don't use GoogleIdTokenVerifier as a member, since calls to google won't happen often, we don't need to create the object in advance to recycle the connnections